### PR TITLE
Adding a Middleware Index Argument to the Proxies

### DIFF
--- a/.jscrc
+++ b/.jscrc
@@ -1,4 +1,5 @@
 {
-    "preset": "crockford",
-    "esnext": true
+    "esnext": true,
+    "esprima": "./node_modules/esprima-fb",
+    "fileExtensions": [".js"]
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ jefferson(app, conf);
 `require('express-jefferson/proxies/promise-handler')`
 
 This proxy accepts promise-based middleware (middleware that accepts two arguments) and wraps them in a promise chain before invoking next().
+
+#### Config Options:
+* haltCondition (optional) - a predicate function that accepts the request and response. If it returns a truthy value, then the middleware chain will be halted. 
+
+### Trace Logger Middleware Proxy
+`require('express-jefferson/proxies/trace-logger')`
+
+This proxy logs invocations of middleware using the debug library.
+
+#### Config Options:
+ * logger (optional) - the name of the debug logger to use. Default is "jefferson:trace-logger"
+
 ## Installation
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel": "^4.7.1",
     "chai": "^2.1.1",
     "del": "^1.1.1",
+    "esprima-fb": "^13001.1001.0-dev-harmony-fb",
     "express": "^4.12.2",
     "gulp": "^3.8.11",
     "gulp-babel": "^4.0.0",

--- a/src/jefferson.js
+++ b/src/jefferson.js
@@ -19,9 +19,9 @@ module.exports = (app, conf) => {
         if (!proxies || !proxies.length) {
             return middleware;
         }
-        return middleware.map((mw) => {
+        return middleware.map((mw, middlewareIndex) => {
             let initProxy = (proxy, delegate) => {
-                return proxy.init(delegate, proxy.config);
+                return proxy.init(delegate, proxy.config, middlewareIndex);
             };
 
             let lastProxy = initProxy(proxies[proxies.length - 1], mw);
@@ -36,16 +36,12 @@ module.exports = (app, conf) => {
         let method = route.method.toLowerCase(),
             path = route.path,
             middleware = possiblyProxy(route.middleware);
-        //jscs:disable
         debug(`routing ${routeName} - ${method} ${path} - ${middleware.length} middlewares`);
-        //jscs:enable
         app[method](path, middleware);
     };
     let wireRoutes = () => {
         let routeNames = Object.keys(conf.routes);
-        //jscs:disable
         debug(`wiring ${routeNames.length} routes`);
-        //jscs:enable
         routeNames.forEach((routeName) => wireRoute(routeName, conf.routes[routeName]));
     };
 

--- a/src/jefferson.test.js
+++ b/src/jefferson.test.js
@@ -23,18 +23,12 @@ describe('Jefferson', () => {
                     'getCollection': {
                         method: 'GET',
                         path: '/test-path',
-                        middleware: [
-                            function () {
-                            }
-                        ]
+                        middleware: [ () => {} ]
                     },
                     'getItem': {
                         method: 'GET',
                         path: '/test-path/:id',
-                        middleware: [
-                            function () {
-                            }
-                        ]
+                        middleware: [ () => {} ]
                     }
                 }
             },
@@ -78,11 +72,11 @@ describe('Jefferson', () => {
                     method: 'GET',
                     path: '/test-path',
                     middleware: [
-                        function (req, res, next) {
+                        (req, res, next) => {
                             initialMiddlewareTriggered = true;
                             next();
                         },
-                        function (req, res) {
+                        (req, res) => {
                             endMiddlewareTriggered = true;
                             res.send('hello!');
                         }
@@ -122,11 +116,11 @@ describe('Jefferson', () => {
                     method: 'GET',
                     path: '/test-path',
                     middleware: [
-                        function (req, res, next) {
+                        (req, res, next) => {
                             initialMiddlewareTriggered = true;
                             next();
                         },
-                        function (req, res) {
+                        (req, res) => {
                             endMiddlewareTriggered = true;
                             res.send('hello!');
                         }
@@ -171,15 +165,9 @@ describe('Jefferson', () => {
                     method: 'GET',
                     path: '/test-path',
                     middleware: [
-                        function (req, res, next) {
-                            next();
-                        },
-                        function (req, res, next) {
-                            next();
-                        },
-                        function (req, res) {
-                            res.send('hello!');
-                        }
+                        (req, res, next) => next(),
+                        (req, res, next) => next(),
+                        (req, res) => res.send('hello!')
                     ]
                 }
             }

--- a/src/proxies/promise-handler.js
+++ b/src/proxies/promise-handler.js
@@ -7,7 +7,7 @@ var JPromise = Promise || require('bluebird');
  * If it throws or resolves to an error, next() is invoked with the error.
  *
  * NOTE: This should be the innermost proxy
- * 
+ *
  * @type {{name: string, init: Function}}
  */
 module.exports = {

--- a/src/proxies/promise-handler.js
+++ b/src/proxies/promise-handler.js
@@ -9,7 +9,10 @@ var JPromise = Promise || require('bluebird');
  */
 module.exports = {
     name: 'Promise Handler',
-    init: (delegate, conf) => {
+    init: (delegate, conf, middlewareIndex) => {
+        if (!delegate || typeof delegate !== "function") {
+            throw new Error("'delegate' argument must exist and be a function. MiddlewareIndex: " + middlewareIndex);
+        }
         return (req, res, next) => {
             let nextTriggered = false;
             let invokeNext = (arg) => {

--- a/src/proxies/promise-handler.js
+++ b/src/proxies/promise-handler.js
@@ -5,6 +5,9 @@ var JPromise = Promise || require('bluebird');
  * A Jefferson proxy that resolves promise-based middleware functions.
  * If a middleware function accepts 2 arguments, we will wrap it in a promise chain.
  * If it throws or resolves to an error, next() is invoked with the error.
+ *
+ * NOTE: This should be the innermost proxy
+ * 
  * @type {{name: string, init: Function}}
  */
 module.exports = {

--- a/src/proxies/promise-handler.test.js
+++ b/src/proxies/promise-handler.test.js
@@ -37,21 +37,25 @@ describe('The promise handler proxy', () => {
     it('can handle when a middleware returns a promise, yet invokes next on its own', (done) => {
         let middleware = (req, res, next) => {
             return Promise.resolve(true)
-            .then(() => req.result = 'coffee')
-            .then(() => next());
+                .then(() => req.result = 'coffee')
+                .then(() => next());
         };
         let wrappedMiddleware = proxy.init(middleware);
         wrappedMiddleware({}, {}, () => done());
     });
 
     it('middlewares can halt flow of next()', () => {
-       let middleware = (req, res, next) => {
-           return Promise.resolve(true)
-           .then(() => res.complete = true);
-       };
+        let middleware = (req, res, next) => {
+            return Promise.resolve(true)
+                .then(() => res.complete = true);
+        };
         let wrappedMiddleware = proxy.init(middleware, {
             haltCondition: (req, res) => res.complete
         });
-        return wrappedMiddleware({}, {}, () => chai.assert.fail(0,0, "did not expect next to be invoked"));
+        return wrappedMiddleware({}, {}, () => chai.assert.fail(0, 0, "did not expect next to be invoked"));
+    });
+
+    it('throws an error when the delegate function is not defined', () => {
+        expect(() => proxy.init()).to.throw();
     });
 });

--- a/src/proxies/trace-logger.js
+++ b/src/proxies/trace-logger.js
@@ -1,0 +1,21 @@
+'use strict';
+let debug = require('debug');
+
+/**
+ * A Jefferson proxy that logs the invocation of a middleware.
+ * @type {{name: string, init: Function}}
+ */
+module.exports = {
+    name: 'Trace Logger',
+    init: (delegate, conf, middlewareIndex) => {
+        if (!delegate || typeof delegate !== "function") {
+            throw new Error("'delegate' argument must exist and be a function. MiddlewareIndex: " + middlewareIndex);
+        }
+        let logger = debug((conf && conf.logger) || 'jefferson:trace-logger');
+
+        return (req, res, next) => {
+            logger('invoking middleware ' + middlewareIndex);
+            delegate(req, res, next);
+        };
+    }
+};

--- a/src/proxies/trace-logger.test.js
+++ b/src/proxies/trace-logger.test.js
@@ -1,0 +1,35 @@
+var proxy = require('./trace-logger'),
+    chai = require('chai'),
+    expect = chai.expect;
+
+describe('The trace logger proxy', () => {
+    it('throws an error when the delegate function is not defined', () => {
+        expect(() => proxy.init()).to.throw();
+    });
+
+    it('can safely invoke a delegate', (done) => {
+        let middleware = (req, res, next) => {
+            req.result = 'coffee';
+            next();
+        };
+        let wrappedMiddleware = proxy.init(middleware, undefined, 0);
+        let req = {};
+        wrappedMiddleware(req, {}, () => {
+            expect(req.result).to.equal('coffee');
+            done()
+        });
+    });
+
+    it('can safely invoke a delegate when configured with a logger name', (done) => {
+        let middleware = (req, res, next) => {
+            req.result = 'coffee';
+            next();
+        };
+        let wrappedMiddleware = proxy.init(middleware, { logger: 'derp' }, 0);
+        let req = {};
+        wrappedMiddleware(req, {}, () => {
+            expect(req.result).to.equal('coffee');
+            done()
+        });
+    });
+});


### PR DESCRIPTION
* Updating JSCS configuration to not complain about template strings
* Adding a trace-logging proxy that logs invocation of the middleware index