### PR TITLE
Streamlined app routing (Requires Major Version bump)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ routes: {
 ```
 * **pre**: (*optional*) - (object) Boilerplate section of pre-middleware functions (see below)
 * **post**: (*optional*) - (object) Boilerplate section of post-middleware functions (see below)
-* **proxies**: (*optional*) - An array of proxy objects invoked around all middleware functions in order. Each proxy object should have an init() function that accepts a delegate middleware function and returns a new middleware function.
+* **proxies**: (*optional*) - An array of proxy objects invoked around all middleware functions in order. (see below)
 * **params**: (*optional*) - A map of path-parameter name to resolver functions.
 ```js
 params: {
@@ -130,6 +130,11 @@ pre: {
     }
 }
 ```
+
+Proxy Definition: 
+* **name**: - The name of the proxy.
+* **init**: - A function that accepts a middleware function, augments it, and returns the augmented proxy.
+* **conf**: (*optional*) - A configuration object that is passed to the proxy init function.
 
 # Proxies provided in Jefferson
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ settings: {
 }
 ```
 
-Boilerplate Config Sections (pre/post):
+###Boilerplate Config Sections (pre/post):
 * **all**: (*optional*) - An array of middleware to be applied to all endpoints.
 * **safe**: (*optional*) - An array of middleware to be applied to all safe endpoints (GET, HEAD, OPTIONS).
 * **unsafe**: (*optional*) - An array of middleware to be applied to all unsafe endpoints (not GET, HEAD, OPTIONS).
@@ -131,7 +131,7 @@ pre: {
 }
 ```
 
-Proxy Definition: 
+###Proxy Definition: 
 * **name**: - The name of the proxy.
 * **init**: - A function that accepts a middleware function, augments it, and returns the augmented proxy.
 * **conf**: (*optional*) - A configuration object that is passed to the proxy init function.

--- a/README.md
+++ b/README.md
@@ -89,27 +89,32 @@ routes: {
     }
 }
 ```
-* **enable**: (*optional*) - An array of settings to enable (http://expressjs.com/api.html#app.enable)
+* **enable**: (*optional*) - An array of settings strings to enable (http://expressjs.com/api.html#app.enable)
 ```js
 enable: ['trust proxy', 'etag']
 ```
-* **disable**: (*optional*) - An array of settings to disable (http://expressjs.com/api.html#app.disable)
+* **disable**: (*optional*) - An array of settings strings to disable (http://expressjs.com/api.html#app.disable)
 ```js
 disable: ['trust proxy', 'etag']
 ```
-* **engines**: (*optional*) - An map of template rendering engines.
+* **engines**: (*optional*) - An map of template rendering engines. `{ <extension>: <engineFunction> }`
 ```js
 engines: {
     'jade': require('jade').__express
 }
 ```
-* **locals**: (*optional*) - (object) An object that will populate app.locals (http://expressjs.com/api.html#app.locals)
+* **locals**: (*optional*) - (object) An object that will populate app.locals (http://expressjs.com/api.html#app.locals) `{ <localName>: <localValue> }`
 ```js
 locals: {
     'a': true
 }
 ```
 * **settings**: (*optional*) - (object) An object that will be iterated to populate application settings using app.set (http://expressjs.com/api.html#app.set) `{ <settingName>: <settingValue> }`
+```js
+settings: {
+    'a': true
+}
+```
 
 Boilerplate Config Sections (pre/post):
 * **all**: (*optional*) - An array of middleware to be applied to all endpoints.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ enable: ['trust proxy', 'etag']
 ```js
 disable: ['trust proxy', 'etag']
 ```
-* **engines**: (*optional*) - An array of objects describing templating engines to use in the app. `{ ext: <string>, callback: <function> }`
+* **engines**: (*optional*) - An map of template rendering engines.
 ```js
-engines: [{
-    ext: 'jade': callback: require('jade').__express
-}]
+engines: {
+    'jade': require('jade').__express
+}
 ```
 * **locals**: (*optional*) - (object) An object that will populate app.locals (http://expressjs.com/api.html#app.locals)
 ```js

--- a/README.md
+++ b/README.md
@@ -34,26 +34,16 @@ var express = require('express'),
             }
         },
         routes: {
-            getBeerList: {
-                method: 'GET',
-                path: '/beers',
-                middleware: [
-                    beerlist.get
-                    send.json
-                ]
+            '/beers': {
+                get: [beerlist.get, send.json]
             },
-            getBeer: {
-                method: 'GET',
-                path: '/beers/:beerId',
-                middleware: [
-                    send.json
-                ]
+            '/beers/:beerId': 
+                get: [beer.get, send.json]
             }
         }
     };
     
 jefferson(app, conf);
-...
 ```
 
 ## Configuration

--- a/src/domain/appsection/engines.js
+++ b/src/domain/appsection/engines.js
@@ -11,9 +11,9 @@ class Engines {
     }
 
     configure() {
-        this.conf.engines.forEach((it) => {
-            debug(`configuring engine ${it.ext}`);
-            this.app.engine(it.ext, it.callback);
+        Object.keys(this.conf.engines).forEach((ext) => {
+            debug(`configuring engine ${ext}`);
+            this.app.engine(ext, this.conf.engines[ext]);
         });
     }
 }

--- a/src/domain/appsection/engines.test.js
+++ b/src/domain/appsection/engines.test.js
@@ -13,12 +13,9 @@ describe("The 'engines' configuration section", () => {
             }
         };
         let conf = {
-            engines: [
-                {
-                    ext: "jade",
-                    callback: () => "derp"
-                }
-            ]
+            engines: {
+                "jade": () => "derp"
+            }
         };
 
         new EngineConfig(app, conf).configure();

--- a/src/domain/appsection/routes/index.js
+++ b/src/domain/appsection/routes/index.js
@@ -7,32 +7,40 @@ var debug = require("debug")("jefferson");
  * Configures routes within the express app.
  */
 class Routes {
-    constructor (app, conf) {
+    constructor(app, conf) {
         this.app = app;
         this.conf = conf;
     }
 
-    configure () {
+    configure() {
         let routeNames = Object.keys(this.conf.routes);
-        debug(`detected ${routeNames.length} routes`);
+        debug(`detected ${routeNames.length} routing paths`);
         routeNames.forEach((routeName) => {
             let route = this.conf.routes[routeName];
             this.wireRoute(routeName, route);
         });
     }
 
+    getMiddlewareChain(method, middleware) {
+        middleware = middlewareComposer.compose(method, middleware, this.conf);
+        return chainProcessor.process(middleware, this.conf);
+    }
+
     /**
      * Configures a single route in the express app/router.
-     * @param routeName The name of the route
-     * @param route The route configuration
+     * @param routePath The route's path
+     * @param routeMethods The route configuration
      */
-    wireRoute (routeName, route) {
-        let method = route.method.toLowerCase();
-        let path = route.path;
-        let middleware = middlewareComposer.compose(route, this.conf);
-        middleware = chainProcessor.process(middleware, this.conf);
-        debug(`"${routeName}": ${method.toUpperCase()} ${path} - ${middleware.length} middlewares`);
-        this.app[method](path, middleware);
+    wireRoute(routePath, routeMethods) {
+        if (routeMethods.method || routeMethods.path) {
+            throw new Error("older-style routes detected. please check the documentation for the new routing style.");
+        }
+        let router = this.app.route(routePath);
+        Object.keys(routeMethods).forEach((method) => {
+            let middleware = this.getMiddlewareChain(method, routeMethods[method]);
+            debug(`"${method.toUpperCase()} ${routePath} - ${middleware.length} middlewares`);
+            router = router[method](middleware);
+        });
     }
 }
 

--- a/src/domain/appsection/routes/middleware_composer.js
+++ b/src/domain/appsection/routes/middleware_composer.js
@@ -14,16 +14,16 @@ let safeMethods = {
  * to it
  */
 module.exports = {
-    compose (route, conf) {
+    compose (method, middleware, conf) {
+        method = method.toLowerCase();
         let result = [];
-        let method = route.method.toLowerCase();
         let isSafe = () => safeMethods[method];
         let add = (x=[]) => result = result.concat(x);
 
         add(conf.pre.all);
         add(isSafe() ? conf.pre.safe : conf.pre.unsafe);
         add(conf.pre.method[method]);
-        add(route.middleware);
+        add(middleware);
         add(conf.post.method[method]);
         add(isSafe() ? conf.post.safe : conf.post.unsafe);
         add(conf.post.all);

--- a/src/domain/configuration.js
+++ b/src/domain/configuration.js
@@ -26,7 +26,7 @@ class Configuration {
         this.locals = conf.locals || {};
         this.enable = conf.enable || [];
         this.disable = conf.disable || [];
-        this.engines = conf.engines || [];
+        this.engines = conf.engines || {};
         this.settings = conf.settings || {};
         this.pre = boilerplateSection(conf.pre);
         this.post = boilerplateSection(conf.post);

--- a/src/jefferson.aliasing.test.js
+++ b/src/jefferson.aliasing.test.js
@@ -13,10 +13,8 @@ describe("Jefferson Alias Configuration", () => {
                 "derp": []
             },
             routes: {
-                "getUser": {
-                    method: "GET",
-                    path: "/test-item",
-                    middleware: [
+                "/test-item": {
+                    get: [
                         (req, res, next) => {
                             req.entity = {id: 1};
                             next();
@@ -34,10 +32,8 @@ describe("Jefferson Alias Configuration", () => {
     it("throws if a alias section is undefined and an alias is referenced", () => {
         let conf = {
             routes: {
-                "getUser": {
-                    method: "GET",
-                    path: "/test-item",
-                    middleware: [
+                "/test-item": {
+                    get: [
                         (req, res, next) => {
                             req.entity = {id: 1};
                             next();
@@ -60,14 +56,14 @@ describe("Jefferson Alias Configuration", () => {
                         req.entity.herp = "derp";
                         next();
                     },
-                    (req, res) => { res.json(req.entity); }
+                    (req, res) => {
+                        res.json(req.entity);
+                    }
                 ]
             },
             routes: {
-                "getUser": {
-                    method: "GET",
-                    path: "/test-item",
-                    middleware: [
+                "/test-item": {
+                    "get": [
                         (req, res, next) => {
                             req.entity = {id: 1};
                             next();
@@ -85,7 +81,9 @@ describe("Jefferson Alias Configuration", () => {
             .get("/test-item")
             .expect(200)
             .end((err, res) => {
-                if (err) { return done(err); }
+                if (err) {
+                    return done(err);
+                }
                 expect(res.body.id).to.equal(1);
                 expect(res.body.herp).to.equal("derp");
                 done();
@@ -101,14 +99,14 @@ describe("Jefferson Alias Configuration", () => {
                         req.entity.herp = "derp";
                         next();
                     },
-                    (req, res) => { res.json(req.entity); }
+                    (req, res) => {
+                        res.json(req.entity);
+                    }
                 ]
             },
             routes: {
-                "getUser": {
-                    method: "GET",
-                    path: "/test-item",
-                    middleware: [
+                "/test-item": {
+                    get: [
                         (req, res, next) => {
                             req.entity = {id: 1};
                             next();
@@ -126,7 +124,9 @@ describe("Jefferson Alias Configuration", () => {
             .get("/test-item")
             .expect(200)
             .end((err, res) => {
-                if (err) { return done(err); }
+                if (err) {
+                    return done(err);
+                }
                 expect(res.body.id).to.equal(1);
                 expect(res.body.herp).to.equal("derp");
                 done();

--- a/src/jefferson.boilerplate-middleware.test.js
+++ b/src/jefferson.boilerplate-middleware.test.js
@@ -28,10 +28,8 @@ describe("Jefferson Pre/Post-Middleware", () => {
                 ]
             },
             routes: {
-                "getItem": {
-                    method: "GET",
-                    path: "/test",
-                    middleware: [
+                "/test": {
+                    get: [
                         middleware.append(2),
                         middleware.append(3),
                         middleware.sendResult
@@ -44,7 +42,7 @@ describe("Jefferson Pre/Post-Middleware", () => {
         return checkRequest(request(app).get("/test"), "0123");
     });
 
-    it("can describe middleware that's invoked before mutable and immutable chains", () => {
+    it("can describe middleware that's invoked before safe and unsafe chains", () => {
         let conf = {
             post: {
                 all: [middleware.sendResult]
@@ -62,35 +60,13 @@ describe("Jefferson Pre/Post-Middleware", () => {
                 }
             },
             routes: {
-                "get": {
-                    method: "GET",
-                    path: "/test",
-                    middleware: [middleware.append("GET")]
-                },
-                "head": {
-                    method: "HEAD",
-                    path: "/test",
-                    middleware: [middleware.append("HEAD")]
-                },
-                "options": {
-                    method: "OPTIONS",
-                    path: "/test",
-                    middleware: [middleware.append("OPTIONS")]
-                },
-                "edit": {
-                    method: "PUT",
-                    path: "/test",
-                    middleware: [middleware.append("PUT")]
-                },
-                "create": {
-                    method: "POST",
-                    path: "/test",
-                    middleware: [middleware.append("POST")]
-                },
-                "delete": {
-                    method: "DELETE",
-                    path: "/test",
-                    middleware: [middleware.append("DELETE")]
+                "/test": {
+                    "get": [middleware.append("GET")],
+                    "head": [middleware.append("HEAD")],
+                    "options": [middleware.append("OPTIONS")],
+                    "put": [middleware.append("PUT")],
+                    "post": [middleware.append("POST")],
+                    "delete": [middleware.append("DELETE")]
                 }
             }
         };
@@ -117,10 +93,8 @@ describe("Jefferson Pre/Post-Middleware", () => {
                 ]
             },
             routes: {
-                "getItem": {
-                    method: "GET",
-                    path: "/test",
-                    middleware: [
+                "/test": {
+                    "get": [
                         middleware.append("0"),
                         middleware.append("1")
                     ]
@@ -148,35 +122,13 @@ describe("Jefferson Pre/Post-Middleware", () => {
                 }
             },
             routes: {
-                "get": {
-                    method: "GET",
-                    path: "/test",
-                    middleware: [middleware.append("GET")]
-                },
-                "head": {
-                    method: "HEAD",
-                    path: "/test",
-                    middleware: [middleware.append("HEAD")]
-                },
-                "options": {
-                    method: "OPTIONS",
-                    path: "/test",
-                    middleware: [middleware.append("OPTIONS")]
-                },
-                "edit": {
-                    method: "PUT",
-                    path: "/test",
-                    middleware: [middleware.append("PUT")]
-                },
-                "create": {
-                    method: "POST",
-                    path: "/test",
-                    middleware: [middleware.append("POST")]
-                },
-                "delete": {
-                    method: "DELETE",
-                    path: "/test",
-                    middleware: [middleware.append("DELETE")]
+                "/test": {
+                    "get": [middleware.append("GET")],
+                    "head": [middleware.append("HEAD")],
+                    "options": [middleware.append("OPTIONS")],
+                    "put": [middleware.append("PUT")],
+                    "post": [middleware.append("POST")],
+                    "delete": [middleware.append("DELETE")]
                 }
             }
         };

--- a/src/jefferson.params.test.js
+++ b/src/jefferson.params.test.js
@@ -16,10 +16,8 @@ describe("Jefferson Parameter Resolution", () => {
                 }
             },
             routes: {
-                "getUser": {
-                    method: "GET",
-                    path: "/users/:userId",
-                    middleware: [
+                "/users/:userId": {
+                    "get": [
                         (req, res) => { res.json(req.user); }
                     ]
                 }

--- a/src/jefferson.proxies.test.js
+++ b/src/jefferson.proxies.test.js
@@ -30,10 +30,8 @@ describe("Jefferson Proxies", () => {
         let conf = {
             proxies: [tripA, tripB],
             routes: {
-                "getItem": {
-                    method: "GET",
-                    path: "/test-path",
-                    middleware: [
+                "/test-path": {
+                    "get": [
                         (req, res, next) => {
                             initialMiddlewareTriggered = true;
                             next();
@@ -74,10 +72,8 @@ describe("Jefferson Proxies", () => {
         let conf = {
             proxies: [],
             routes: {
-                "getItem": {
-                    method: "GET",
-                    path: "/test-path",
-                    middleware: [
+                "/test-path": {
+                    "get": [
                         (req, res, next) => {
                             initialMiddlewareTriggered = true;
                             next();
@@ -123,10 +119,8 @@ describe("Jefferson Proxies", () => {
                 }
             ],
             routes: {
-                "getItem": {
-                    method: "GET",
-                    path: "/test-path",
-                    middleware: [
+                "/test-path": {
+                    "get": [
                         (req, res, next) => next(),
                         (req, res, next) => next(),
                         (req, res) => res.send("hello!")

--- a/src/jefferson.routing.test.js
+++ b/src/jefferson.routing.test.js
@@ -2,7 +2,6 @@
 var chai = require("chai"),
     express = require("express"),
     jefferson = require("./jefferson");
-let debug = require("debug")("jefferson:test");
 let expect = chai.expect;
 
 describe("Jefferson", () => {
@@ -18,6 +17,32 @@ describe("Jefferson", () => {
     it("configures an application", () => {
         let conf = {
                 routes: {
+                    "/test-path": {
+                        get: [() => {}]
+                    },
+                    "/test-path/:id": {
+                        get: [() => {}],
+                        post: [() => {}],
+                        put: [() => {}]
+                    }
+                }
+            },
+            app = express();
+
+        jefferson(app, conf);
+        /*eslint-disable*/
+        let appRoutes = app._router.stack.filter((it) => it.route);
+        /*eslint-enable*/
+        expect(appRoutes.length).to.equal(2);
+        expect(appRoutes[0].route.methods.get).to.be.true;
+        expect(appRoutes[1].route.methods.get).to.be.true;
+        expect(appRoutes[1].route.methods.post).to.be.true;
+        expect(appRoutes[1].route.methods.put).to.be.true;
+    });
+
+    it("will throw with an older configuration", () => {
+        let conf = {
+                routes: {
                     "getCollection": {
                         method: "GET",
                         path: "/test-path",
@@ -30,15 +55,8 @@ describe("Jefferson", () => {
                     }
                 }
             },
-            routed = 0,
-            app = {
-                get: (path, middleware) => {
-                    routed++;
-                    debug("mock application routing", path, middleware);
-                }
-            };
+            app = express();
 
-        jefferson(app, conf);
-        expect(routed).to.equal(2);
+        expect(() => jefferson(app, conf)).to.throw();
     });
 });


### PR DESCRIPTION
Streamlining application routing so that instead of repeating boilerplate keys, we use a covention of laying them out.

This is the old way, andt there's a lot of useless cruft.
```js
routes: {
   'getById': {
      method: 'GET'
      path: '/things/:id'
      middleware: []
   }
}
```

This is the new way: 
````js
routes: {
    '/things/:id': {
        get: []
    }
}
````